### PR TITLE
Increase b2b-api-php version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## UNRELEASED
+
+### Changed
+
+- Minimal required `avtocod/b2b-api-php` package version now is `^4.1`
+- Using method `expectExceptionMessageMatches` instead of `expectExceptionMessageRegExp` in tests
+
 ## v4.0.0
 
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^7.2",
-        "avtocod/b2b-api-php": "^4.0",
+        "avtocod/b2b-api-php": "^4.1",
         "illuminate/support": "~6.0 || ~7.0 || ~8.0",
         "illuminate/container": "~6.0 || ~7.0 || ~8.0",
         "illuminate/contracts": "~6.0 || ~7.0 || ~8.0",

--- a/tests/Connections/ConnectionsFactoryTest.php
+++ b/tests/Connections/ConnectionsFactoryTest.php
@@ -124,7 +124,7 @@ class ConnectionsFactoryTest extends AbstractTestCase
     public function testDefaultThrowsAnException(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessageRegExp('~Default.*not set~i');
+        $this->expectExceptionMessageMatches('~Default.*not set~i');
 
         $this->factory = new ConnectionsFactory($this->settings);
 
@@ -186,7 +186,7 @@ class ConnectionsFactoryTest extends AbstractTestCase
     public function testMakeThrowsAnExceptionWhenUnknownConnectionNamePassed(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessageRegExp('~named.*not exist~i');
+        $this->expectExceptionMessageMatches('~named.*not exist~i');
 
         $this->factory->make(Str::random());
     }
@@ -226,7 +226,7 @@ class ConnectionsFactoryTest extends AbstractTestCase
     public function testFactoryThrownAnExceptionWhenAuthPasswordAndTokenNotPassed(): void
     {
         $this->expectException(ErrorException::class);
-        $this->expectExceptionMessageRegExp('~password~');
+        $this->expectExceptionMessageMatches('~password~');
 
         $this->factory->addFactory($name = Str::random(), [
             'base_uri' => 'https://httpbin.org/delete/',
@@ -246,7 +246,7 @@ class ConnectionsFactoryTest extends AbstractTestCase
     public function testFactoryThrownAnExceptionWhenAuthUserAndTokenNotPassed(): void
     {
         $this->expectException(ErrorException::class);
-        $this->expectExceptionMessageRegExp('~username~');
+        $this->expectExceptionMessageMatches('~username~');
 
         $this->factory->addFactory($name = Str::random(), [
             'base_uri' => 'https://httpbin.org/delete/',
@@ -266,7 +266,7 @@ class ConnectionsFactoryTest extends AbstractTestCase
     public function testFactoryThrownAnExceptionWhenAuthDomainAndTokenNotPassed(): void
     {
         $this->expectException(ErrorException::class);
-        $this->expectExceptionMessageRegExp('~domain~');
+        $this->expectExceptionMessageMatches('~domain~');
 
         $this->factory->addFactory($name = Str::random(), [
             'base_uri' => 'https://httpbin.org/delete/',

--- a/tests/ReportTypes/RepositoryTest.php
+++ b/tests/ReportTypes/RepositoryTest.php
@@ -104,7 +104,7 @@ class RepositoryTest extends AbstractTestCase
     public function testDefaultThrownAnException(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessageRegExp('~Default.*not set~i');
+        $this->expectExceptionMessageMatches('~Default.*not set~i');
 
         $this->repository = new Repository($this->settings);
 
@@ -119,7 +119,7 @@ class RepositoryTest extends AbstractTestCase
     public function testGetThrownAnException(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessageRegExp('~named.*not exist~i');
+        $this->expectExceptionMessageMatches('~named.*not exist~i');
 
         $this->repository->get(Str::random());
     }


### PR DESCRIPTION
## Description

### Changed

- Minimal required `avtocod/b2b-api-php` package version now is `^4.1`
- Using method `expectExceptionMessageMatches` instead of `expectExceptionMessageRegExp` in tests


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in `CHANGELOG.md` file


