### PR TITLE
Add php8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs: # Docs: <https://git.io/JvxXE>
         setup: [basic, lowest]
         laravel: [default]
         coverage: [yes]
-        php: ['7.2', '7.3', '7.4']
+        php: ['7.3', '7.4', '8.0']
         include:
           - php: '7.3'
             setup: basic
@@ -49,20 +49,17 @@ jobs: # Docs: <https://git.io/JvxXE>
           key: ${{ runner.os }}-composer-${{ matrix.setup }}-${{ hashFiles('**/composer.json') }}
           restore-keys: ${{ runner.os }}-composer-
 
-      - name: Install Composer 'hirak/prestissimo' package
-        run: composer global require hirak/prestissimo --update-no-dev --no-progress --ansi
-
       - name: Install lowest Composer dependencies
         if: matrix.setup == 'lowest'
-        run: composer update --prefer-dist --no-suggest --prefer-lowest --ansi
+        run: composer update --prefer-dist --prefer-lowest --ansi
 
       - name: Install basic Composer dependencies
         if: matrix.setup == 'basic'
-        run: composer update --prefer-dist --no-suggest --ansi
+        run: composer update --prefer-dist --ansi
 
       - name: Install specific laravel version
         if: matrix.laravel != 'default'
-        run: composer require --dev --update-with-dependencies --prefer-dist --no-suggest --ansi laravel/laravel "${{ matrix.laravel }}"
+        run: composer require --dev --update-with-dependencies --prefer-dist --ansi laravel/laravel "${{ matrix.laravel }}"
 
       - name: Show most important packages versions
         run: composer info | grep -e laravel -e phpunit -e phpstan

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## Unreleased
+
+### Added
+
+- Support PHP `8.x` [#16]
+- Laravel `9.x` is supported now
+
+### Changed
+
+- Composer `2.x` is supported now
+- Minimal PHP version now is `7.3`
+
+[#16]:https://github.com/avtocod/b2b-api-php-laravel/issues/16
+
 ## v4.2.0
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,14 @@
-FROM php:7.3.5-alpine
+FROM php:8.1.7-alpine
 
-ENV \
-    COMPOSER_ALLOW_SUPERUSER="1" \
-    COMPOSER_HOME="/tmp/composer"
-
-COPY --from=composer:1.10.10 /usr/bin/composer /usr/bin/composer
+COPY --from=composer:2.3.9 /usr/bin/composer /usr/bin/composer
 
 RUN set -x \
     && apk add --no-cache binutils git \
     && apk add --no-cache --virtual .build-deps autoconf pkgconf make g++ gcc 1>/dev/null \
     # install xdebug (for testing with code coverage), but do not enable it
-    && pecl install xdebug-2.9.6 1>/dev/null \
+    && pecl install xdebug-3.1.5 1>/dev/null \
     && apk del .build-deps \
     && mkdir /src ${COMPOSER_HOME} \
-    && composer global require 'hirak/prestissimo' --no-interaction --no-suggest --prefer-dist \
     && ln -s /usr/bin/composer /usr/bin/c \
     && chmod -R 777 ${COMPOSER_HOME} \
     && composer --version \

--- a/Makefile
+++ b/Makefile
@@ -17,13 +17,13 @@ build: ## Build docker images, required for current package environment
 	docker-compose build
 
 latest: clean ## Install latest php dependencies
-	docker-compose run $(RUN_APP_ARGS) app composer update -n --ansi --no-suggest --prefer-dist --prefer-stable
+	docker-compose run $(RUN_APP_ARGS) app composer update -n --ansi --prefer-dist --prefer-stable
 
 install: clean ## Install regular php dependencies
-	docker-compose run $(RUN_APP_ARGS) app composer update -n --prefer-dist --no-interaction --no-suggest
+	docker-compose run $(RUN_APP_ARGS) app composer update -n --prefer-dist --no-interaction
 
 lowest: clean ## Install lowest php dependencies
-	docker-compose run $(RUN_APP_ARGS) app composer update -n --ansi --no-suggest --prefer-dist --prefer-lowest
+	docker-compose run $(RUN_APP_ARGS) app composer update -n --ansi --prefer-dist --prefer-lowest
 
 test: ## Execute php tests and linters
 	docker-compose run $(RUN_APP_ARGS) app composer test

--- a/composer.json
+++ b/composer.json
@@ -16,20 +16,20 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.3|^8.0",
         "avtocod/b2b-api-php": "^4.1",
-        "illuminate/support": "~6.0 || ~7.0 || ~8.0",
-        "illuminate/container": "~6.0 || ~7.0 || ~8.0",
-        "illuminate/contracts": "~6.0 || ~7.0 || ~8.0",
-        "illuminate/events": "~6.0 || ~7.0 || ~8.0",
-        "illuminate/config": "~6.0 || ~7.0 || ~8.0"
+        "illuminate/support": "~6.0 || ~7.0 || ~8.0 || ~9.0",
+        "illuminate/container": "~6.0 || ~7.0 || ~8.0 || ~9.0",
+        "illuminate/contracts": "~6.0 || ~7.0 || ~8.0 || ~9.0",
+        "illuminate/events": "~6.0 || ~7.0 || ~8.0 || ~9.0",
+        "illuminate/config": "~6.0 || ~7.0 || ~8.0 || ~9.0"
     },
     "require-dev": {
         "ext-json": "*",
-        "laravel/laravel": "~6.0 || ~7.0 || ~8.0",
+        "laravel/laravel": "~6.0 || ~7.0 || ~8.0 || ~9.0",
         "mockery/mockery": "^1.3",
-        "phpstan/phpstan": "~0.12",
-        "phpunit/phpunit": "^8.0",
+        "phpstan/phpstan": "~0.12.92",
+        "phpunit/phpunit": "^8.5.4",
         "avto-dev/guzzle-url-mock": "^1.5"
     },
     "autoload": {


### PR DESCRIPTION
## Description

### Added

- Support PHP `8.x` [#16]
- Laravel `9.x` is supported now

### Changed

- Composer `2.x` is supported now

[#16]:https://github.com/avtocod/b2b-api-php-laravel/issues/16

Fixes #16 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in `CHANGELOG.md` file

