### PR TITLE
Add support for Laravel 11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs: # Docs: <https://git.io/JvxXE>
         setup: [basic, lowest]
         laravel: [default]
         coverage: [yes]
-        php: ['8.1','8.2','8.3']
+        php: ['8.2','8.3']
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs: # Docs: <https://git.io/JvxXE>
         setup: [basic, lowest]
         laravel: [default]
         coverage: [yes]
-        php: ['8.2','8.3']
+        php: ['8.1','8.2','8.3']
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,15 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 
 ### Added
 
-- Support Laravel 11
+- Support for Laravel 11
 
 ### Changed
 
-- Up minimal `PHP` version to `8.2`
-- Up minimal version for `illuminate`-dependencies
+- Composer updated from v2.6.6 to v2.8.3
+
+### Removed
+
+- Obsolete attribute `version` from docker-compose.yml
 
 ## v4.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## Unreleased
+
+### Added
+
+- Support Laravel 11
+
+### Changed
+
+- Up minimal `PHP` version to `8.2`
+- Up minimal version for `illuminate`-dependencies
+
 ## v4.4.0
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM php:8.2.26-alpine
 
-COPY --from=composer:2.6.6 /usr/bin/composer /usr/bin/composer
+COPY --from=composer:2.8.3 /usr/bin/composer /usr/bin/composer
 
 RUN set -x \
     && apk add --no-cache binutils git \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.1.7-alpine
+FROM php:8.2.26-alpine
 
 COPY --from=composer:2.6.6 /usr/bin/composer /usr/bin/composer
 

--- a/composer.json
+++ b/composer.json
@@ -16,17 +16,17 @@
         }
     ],
     "require": {
-        "php": "^8.2",
+        "php": "^8.1",
         "avtocod/b2b-api-php": "^4.1",
-        "illuminate/support": "^11.0",
-        "illuminate/container": "^11.0",
-        "illuminate/contracts": "^11.0",
-        "illuminate/events": "^11.0",
-        "illuminate/config": "^11.0"
+        "illuminate/support": "^10.0 | ^11.0",
+        "illuminate/container": "^10.0 | ^11.0",
+        "illuminate/contracts": "^10.0 | ^11.0",
+        "illuminate/events": "^10.0 | ^11.0",
+        "illuminate/config": "^10.0 | ^11.0"
     },
     "require-dev": {
         "ext-json": "*",
-        "laravel/laravel": "^11.0",
+        "laravel/laravel": "^10.0 | ^11.0",
         "mockery/mockery": "^1.6",
         "phpstan/phpstan": "^1.10",
         "phpunit/phpunit": "^10.5",

--- a/composer.json
+++ b/composer.json
@@ -16,17 +16,17 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "avtocod/b2b-api-php": "^4.1",
-        "illuminate/support": "^10.0",
-        "illuminate/container": "^10.0",
-        "illuminate/contracts": "^10.0",
-        "illuminate/events": "^10.0",
-        "illuminate/config": "^10.0"
+        "illuminate/support": "^11.0",
+        "illuminate/container": "^11.0",
+        "illuminate/contracts": "^11.0",
+        "illuminate/events": "^11.0",
+        "illuminate/config": "^11.0"
     },
     "require-dev": {
         "ext-json": "*",
-        "laravel/laravel": "^10.0",
+        "laravel/laravel": "^11.0",
         "mockery/mockery": "^1.6",
         "phpstan/phpstan": "^1.10",
         "phpunit/phpunit": "^10.5",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.2'
-
 volumes:
   composer-data:
 


### PR DESCRIPTION
## Description

### Added

- Support for Laravel 11

### Changed

- Composer updated from v2.6.6 to v2.8.3

### Removed

- Obsolete attribute `version` from docker-compose.yml

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in `CHANGELOG.md` file

<!--

About your changes in `CHANGELOG.md`:

* Add new version header like `## v1.x.x` or `## UNRELEASED`, if it does not exists
* Add description under `added`/`changed`/`fixed` sections
* Add reference to closed issues `[#000]`
* Add link to issue in the end of document

-->
